### PR TITLE
Fix for PyQt6/PySide2 compatibility

### DIFF
--- a/docs/tutorial/graphical.rst
+++ b/docs/tutorial/graphical.rst
@@ -113,7 +113,7 @@ Below we adapt our previous example to use a ManagedWindow. ::
     import random
     from time import sleep
     from pymeasure.log import console_log
-    from pymeasure.display.Qt import QtGui
+    from pymeasure.display.Qt import QtWidgets
     from pymeasure.display.windows import ManagedWindow
     from pymeasure.experiment import Procedure, Results
     from pymeasure.experiment import IntegerParameter, FloatParameter, Parameter
@@ -169,10 +169,10 @@ Below we adapt our previous example to use a ManagedWindow. ::
 
 
     if __name__ == "__main__":
-        app = QtGui.QApplication(sys.argv)
+        app = QtWidgets.QApplication(sys.argv)
         window = MainWindow()
         window.show()
-        sys.exit(app.exec_())
+        sys.exit(app.exec())
 
 
 

--- a/examples/Basic/gui.py
+++ b/examples/Basic/gui.py
@@ -16,7 +16,7 @@ from time import sleep
 
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter
 from pymeasure.experiment import Results
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 
 import logging
@@ -78,7 +78,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Basic/gui.py
+++ b/examples/Basic/gui.py
@@ -81,4 +81,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Basic/gui_custom_inputs.py
+++ b/examples/Basic/gui_custom_inputs.py
@@ -17,7 +17,7 @@ from time import sleep
 
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter
 from pymeasure.experiment import Results
-from pymeasure.display.Qt import QtGui, fromUi
+from pymeasure.display.Qt import QtWidgets, fromUi
 from pymeasure.display.windows import ManagedWindow
 
 import logging
@@ -88,7 +88,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Basic/gui_custom_inputs.py
+++ b/examples/Basic/gui_custom_inputs.py
@@ -91,4 +91,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Basic/gui_estimator.py
+++ b/examples/Basic/gui_estimator.py
@@ -130,4 +130,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Basic/gui_estimator.py
+++ b/examples/Basic/gui_estimator.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, FloatParameter
 from pymeasure.experiment import Results
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 
 import logging
@@ -127,7 +127,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Basic/gui_foreign_instrument.py
+++ b/examples/Basic/gui_foreign_instrument.py
@@ -17,7 +17,7 @@ from time import sleep
 
 from pymeasure.experiment import Procedure, IntegerParameter, FloatParameter
 from pymeasure.experiment import Results
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 
 # Import the InstrumentKit package
@@ -93,7 +93,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Basic/gui_foreign_instrument.py
+++ b/examples/Basic/gui_foreign_instrument.py
@@ -96,4 +96,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Basic/gui_sequencer.py
+++ b/examples/Basic/gui_sequencer.py
@@ -17,7 +17,7 @@ from time import sleep
 from pymeasure.experiment import Procedure, IntegerParameter, Parameter, \
     FloatParameter
 from pymeasure.experiment import Results
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 
 import logging
@@ -85,7 +85,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Basic/gui_sequencer.py
+++ b/examples/Basic/gui_sequencer.py
@@ -88,4 +88,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Basic/image_gui.py
+++ b/examples/Basic/image_gui.py
@@ -99,4 +99,4 @@ if __name__ == "__main__":
     app = QtWidgets.QApplication(sys.argv)
     window = TestImageGUI()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Basic/image_gui.py
+++ b/examples/Basic/image_gui.py
@@ -16,7 +16,7 @@ from pymeasure.experiment import Results, unique_filename
 from pymeasure.experiment import Procedure
 from pymeasure.display.windows import ManagedImageWindow  # new ManagedWindow class
 from pymeasure.experiment import FloatParameter
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 
 import logging
 log = logging.getLogger(__name__)
@@ -96,7 +96,7 @@ class TestImageGUI(ManagedImageWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = TestImageGUI()
     window.show()
     sys.exit(app.exec_())

--- a/examples/Current-Voltage Measurements/iv_keithley.py
+++ b/examples/Current-Voltage Measurements/iv_keithley.py
@@ -18,7 +18,7 @@ from time import sleep
 import numpy as np
 
 from pymeasure.instruments.keithley import Keithley2000, Keithley2400
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 from pymeasure.experiment import (
     Procedure, FloatParameter, unique_filename, Results
@@ -119,7 +119,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/examples/Current-Voltage Measurements/iv_yokogawa.py
+++ b/examples/Current-Voltage Measurements/iv_yokogawa.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from pymeasure.instruments.keithley import Keithley2000
 from pymeasure.instruments.yokogawa import Yokogawa7651
-from pymeasure.display.Qt import QtGui
+from pymeasure.display.Qt import QtWidgets
 from pymeasure.display.windows import ManagedWindow
 from pymeasure.experiment import (
     Procedure, FloatParameter, unique_filename, Results
@@ -119,7 +119,7 @@ class MainWindow(ManagedWindow):
 
 
 if __name__ == "__main__":
-    app = QtGui.QApplication(sys.argv)
+    app = QtWidgets.QApplication(sys.argv)
     window = MainWindow()
     window.show()
-    sys.exit(app.exec_())
+    sys.exit(app.exec())

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -31,6 +31,11 @@ log.addHandler(logging.NullHandler())
 
 QtCore.QSignal = QtCore.Signal
 
+# Should be removed when PySide2 provides QtWidgets.QApplication.exec() or when support for PySide2
+# is dropped
+if not hasattr(QtWidgets.QApplication, 'exec'):
+    QtWidgets.QApplication.exec = QtWidgets.QApplication.exec_
+
 
 def fromUi(*args, **kwargs):
     """ Returns a Qt object constructed using loadUiType

--- a/pymeasure/display/Qt.py
+++ b/pymeasure/display/Qt.py
@@ -24,7 +24,7 @@
 
 import logging
 
-from pyqtgraph.Qt import QtGui, QtCore, loadUiType
+from pyqtgraph.Qt import QtGui, QtCore, QtWidgets, loadUiType
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())

--- a/pymeasure/display/browser.py
+++ b/pymeasure/display/browser.py
@@ -42,8 +42,8 @@ class BrowserItem(QtGui.QTreeWidgetItem):
         pixelmap = QtGui.QPixmap(24, 24)
         pixelmap.fill(color)
         self.setIcon(0, QtGui.QIcon(pixelmap))
-        self.setFlags(self.flags() | QtCore.Qt.ItemIsUserCheckable)
-        self.setCheckState(0, QtCore.Qt.Checked)
+        self.setFlags(self.flags() | QtCore.Qt.ItemFlag.ItemIsUserCheckable)
+        self.setCheckState(0, QtCore.Qt.CheckState.Checked)
         self.setText(1, basename(results.data_filename))
 
         self.setStatus(results.procedure.status)
@@ -102,7 +102,7 @@ class Browser(QtGui.QTreeWidget):
         self.setHeaderLabels(header_labels)
         self.setSortingEnabled(True)
         if sort_by_filename:
-            self.sortItems(1, QtCore.Qt.AscendingOrder)
+            self.sortItems(1, QtCore.Qt.SortOrder.AscendingOrder)
 
         for i, width in enumerate([80, 140]):
             self.header().resizeSection(i, width)

--- a/pymeasure/display/curves.py
+++ b/pymeasure/display/curves.py
@@ -172,7 +172,7 @@ class Crosshairs(QtCore.QObject):
         """ Initiates the crosshars onto a plot given the pen style.
 
         Example pen:
-        pen=pg.mkPen(color='#AAAAAA', style=QtCore.Qt.DashLine)
+        pen=pg.mkPen(color='#AAAAAA', style=QtCore.Qt.PenStyle.DashLine)
         """
         super().__init__()
 

--- a/pymeasure/display/inputs.py
+++ b/pymeasure/display/inputs.py
@@ -114,7 +114,7 @@ class IntegerInput(Input, QtGui.QSpinBox):
             self.setSingleStep(parameter.step)
             self.setEnabled(True)
         else:
-            self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
+            self.setButtonSymbols(QtGui.QAbstractSpinBox.ButtonSymbols.NoButtons)
 
     def set_parameter(self, parameter):
         # Override from :class:`Input`
@@ -124,9 +124,10 @@ class IntegerInput(Input, QtGui.QSpinBox):
 
     def stepEnabled(self):
         if self.parameter.step:
-            return QtGui.QAbstractSpinBox.StepUpEnabled | QtGui.QAbstractSpinBox.StepDownEnabled
+            return QtGui.QAbstractSpinBox.StepEnabledFlag.StepUpEnabled | \
+                   QtGui.QAbstractSpinBox.StepEnabledFlag.StepDownEnabled
         else:
-            return QtGui.QAbstractSpinBox.StepNone
+            return QtGui.QAbstractSpinBox.StepEnabledFlag.StepNone
 
 
 class BooleanInput(Input, QtGui.QCheckBox):
@@ -211,7 +212,7 @@ class ScientificInput(Input, QtGui.QDoubleSpinBox):
             self.setSingleStep(parameter.step)
             self.setEnabled(True)
         else:
-            self.setButtonSymbols(QtGui.QAbstractSpinBox.NoButtons)
+            self.setButtonSymbols(QtGui.QAbstractSpinBox.ButtonSymbols.NoButtons)
 
     def set_parameter(self, parameter):
         # Override from :class:`Input`
@@ -225,7 +226,7 @@ class ScientificInput(Input, QtGui.QDoubleSpinBox):
         self.setDecimals(parameter.decimals)
         self.setMinimum(parameter.minimum)
         self.setMaximum(parameter.maximum)
-        self.validator.setNotation(QtGui.QDoubleValidator.ScientificNotation)
+        self.validator.setNotation(QtGui.QDoubleValidator.Notation.ScientificNotation)
         super().set_parameter(parameter)  # default gets set here, after min/max
 
     def validate(self, text, pos):
@@ -255,6 +256,7 @@ class ScientificInput(Input, QtGui.QDoubleSpinBox):
 
     def stepEnabled(self):
         if self.parameter.step:
-            return QtGui.QAbstractSpinBox.StepUpEnabled | QtGui.QAbstractSpinBox.StepDownEnabled
+            return QtGui.QAbstractSpinBox.StepEnabledFlag.StepUpEnabled | \
+                   QtGui.QAbstractSpinBox.StepEnabledFlag.StepDownEnabled
         else:
-            return QtGui.QAbstractSpinBox.StepNone
+            return QtGui.QAbstractSpinBox.StepEnabledFlag.StepNone

--- a/pymeasure/display/plotter.py
+++ b/pymeasure/display/plotter.py
@@ -27,7 +27,7 @@ import logging
 import sys
 import time
 
-from .Qt import QtGui
+from .Qt import QtWidgets
 from .windows import PlotterWindow
 from ..thread import StoppableThread
 
@@ -51,12 +51,12 @@ class Plotter(StoppableThread):
         self.linewidth = linewidth
 
     def run(self):
-        app = QtGui.QApplication(sys.argv)
+        app = QtWidgets.QApplication(sys.argv)
         window = PlotterWindow(self, refresh_time=self.refresh_time, linewidth=self.linewidth)
         self.setup_plot(window.plot)
         app.aboutToQuit.connect(window.quit)
         window.show()
-        app.exec_()
+        app.exec()
 
     def setup_plot(self, plot):
         """

--- a/pymeasure/display/widgets/directory_widget.py
+++ b/pymeasure/display/widgets/directory_widget.py
@@ -41,11 +41,13 @@ class DirectoryLineEdit(QtGui.QLineEdit):
         super().__init__(parent=parent)
 
         completer = QtGui.QCompleter(self)
-        completer.setCompletionMode(QtGui.QCompleter.PopupCompletion)
+        completer.setCompletionMode(QtGui.QCompleter.CompletionMode.PopupCompletion)
 
         model = QtGui.QDirModel(completer)
-        model.setFilter(QtCore.QDir.Dirs | QtCore.QDir.Drives |
-                        QtCore.QDir.NoDotAndDotDot | QtCore.QDir.AllDirs)
+        model.setFilter(QtCore.QDir.Filter.Dirs |
+                        QtCore.QDir.Filter.Drives |
+                        QtCore.QDir.Filter.NoDotAndDotDot |
+                        QtCore.QDir.Filter.AllDirs)
         completer.setModel(model)
 
         self.setCompleter(completer)
@@ -55,7 +57,7 @@ class DirectoryLineEdit(QtGui.QLineEdit):
             getattr(QtGui.QStyle, 'SP_DialogOpenButton')))
         browse_action.triggered.connect(self.browse_triggered)
 
-        self.addAction(browse_action, QtGui.QLineEdit.TrailingPosition)
+        self.addAction(browse_action, QtGui.QLineEdit.ActionPosition.TrailingPosition)
 
     def _get_starting_directory(self):
         current_text = self.text()

--- a/pymeasure/display/widgets/directory_widget.py
+++ b/pymeasure/display/widgets/directory_widget.py
@@ -24,13 +24,13 @@
 
 import logging
 
-from ..Qt import QtCore, QtGui
+from ..Qt import QtCore, QtGui, QtWidgets
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
 
 
-class DirectoryLineEdit(QtGui.QLineEdit):
+class DirectoryLineEdit(QtWidgets.QLineEdit):
     """
     Widget that allows to choose a directory path.
     A completer is implemented for quick completion.
@@ -40,10 +40,10 @@ class DirectoryLineEdit(QtGui.QLineEdit):
     def __init__(self, parent=None):
         super().__init__(parent=parent)
 
-        completer = QtGui.QCompleter(self)
-        completer.setCompletionMode(QtGui.QCompleter.CompletionMode.PopupCompletion)
+        completer = QtWidgets.QCompleter(self)
+        completer.setCompletionMode(QtWidgets.QCompleter.CompletionMode.PopupCompletion)
 
-        model = QtGui.QDirModel(completer)
+        model = QtGui.QFileSystemModel(completer)
         model.setFilter(QtCore.QDir.Filter.Dirs |
                         QtCore.QDir.Filter.Drives |
                         QtCore.QDir.Filter.NoDotAndDotDot |
@@ -54,10 +54,10 @@ class DirectoryLineEdit(QtGui.QLineEdit):
 
         browse_action = QtGui.QAction(self)
         browse_action.setIcon(self.style().standardIcon(
-            getattr(QtGui.QStyle, 'SP_DialogOpenButton')))
+            getattr(QtWidgets.QStyle.StandardPixmap, 'SP_DialogOpenButton')))
         browse_action.triggered.connect(self.browse_triggered)
 
-        self.addAction(browse_action, QtGui.QLineEdit.ActionPosition.TrailingPosition)
+        self.addAction(browse_action, QtWidgets.QLineEdit.ActionPosition.TrailingPosition)
 
     def _get_starting_directory(self):
         current_text = self.text()
@@ -68,7 +68,7 @@ class DirectoryLineEdit(QtGui.QLineEdit):
             return '/'
 
     def browse_triggered(self):
-        path = QtGui.QFileDialog.getExistingDirectory(
+        path = QtWidgets.QFileDialog.getExistingDirectory(
             self, 'Directory', self._get_starting_directory())
         if path != '':
             self.setText(path)

--- a/pymeasure/display/widgets/estimator_widget.py
+++ b/pymeasure/display/widgets/estimator_widget.py
@@ -137,7 +137,7 @@ class EstimatorWidget(QtGui.QWidget):
 
             qle = QtGui.QLineEdit(self)
             qle.setEnabled(False)
-            qle.setAlignment(QtCore.Qt.AlignRight)
+            qle.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
 
             self.line_edits.append((qlb, qle))
 

--- a/pymeasure/display/widgets/plot_frame.py
+++ b/pymeasure/display/widgets/plot_frame.py
@@ -58,8 +58,8 @@ class PlotFrame(QtGui.QFrame):
     def _setup_ui(self):
         self.setAutoFillBackground(False)
         self.setStyleSheet("background: #fff")
-        self.setFrameShape(QtGui.QFrame.StyledPanel)
-        self.setFrameShadow(QtGui.QFrame.Sunken)
+        self.setFrameShape(QtGui.QFrame.Shape.StyledPanel)
+        self.setFrameShadow(QtGui.QFrame.Shadow.Sunken)
         self.setMidLineWidth(1)
 
         vbox = QtGui.QVBoxLayout(self)
@@ -70,7 +70,9 @@ class PlotFrame(QtGui.QFrame):
         self.coordinates.setStyleSheet("background: #fff")
         self.coordinates.setText("")
         self.coordinates.setAlignment(
-            QtCore.Qt.AlignRight | QtCore.Qt.AlignTrailing | QtCore.Qt.AlignVCenter)
+            QtCore.Qt.AlignmentFlag.AlignRight |
+            QtCore.Qt.AlignmentFlag.AlignTrailing |
+            QtCore.Qt.AlignmentFlag.AlignVCenter)
 
         vbox.addWidget(self.plot_widget)
         vbox.addWidget(self.coordinates)
@@ -79,7 +81,8 @@ class PlotFrame(QtGui.QFrame):
         self.plot = self.plot_widget.getPlotItem()
 
         self.crosshairs = Crosshairs(self.plot,
-                                     pen=pg.mkPen(color='#AAAAAA', style=QtCore.Qt.DashLine))
+                                     pen=pg.mkPen(color='#AAAAAA',
+                                                  style=QtCore.Qt.PenStyle.DashLine))
         self.crosshairs.coordinates.connect(self.update_coordinates)
 
         self.timer = QtCore.QTimer()

--- a/pymeasure/display/widgets/results_dialog.py
+++ b/pymeasure/display/widgets/results_dialog.py
@@ -49,7 +49,7 @@ class ResultsDialog(QtGui.QFileDialog):
         super().__init__(parent)
         self.columns = columns
         self.x_axis, self.y_axis = x_axis, y_axis
-        self.setOption(QtGui.QFileDialog.DontUseNativeDialog, True)
+        self.setOption(QtGui.QFileDialog.Option.DontUseNativeDialog, True)
         self._setup_ui()
 
     def _setup_ui(self):
@@ -79,7 +79,7 @@ class ResultsDialog(QtGui.QFileDialog):
         self.setMinimumSize(900, 500)
         self.resize(900, 500)
 
-        self.setFileMode(QtGui.QFileDialog.ExistingFiles)
+        self.setFileMode(QtGui.QFileDialog.FileMode.ExistingFiles)
         self.currentChanged.connect(self.update_plot)
 
     def update_plot(self, filename):
@@ -110,4 +110,4 @@ class ResultsDialog(QtGui.QFileDialog):
             for key, param in results.procedure.parameter_objects().items():
                 new_item = QtGui.QTreeWidgetItem([param.name, str(param)])
                 self.preview_param.addTopLevelItem(new_item)
-            self.preview_param.sortItems(0, QtCore.Qt.AscendingOrder)
+            self.preview_param.sortItems(0, QtCore.Qt.SortOrder.AscendingOrder)

--- a/pymeasure/display/windows.py
+++ b/pymeasure/display/windows.py
@@ -256,7 +256,7 @@ class ManagedWindowBase(QtGui.QMainWindow):
         self.browser_widget.open_button.clicked.connect(self.open_experiment)
         self.browser = self.browser_widget.browser
 
-        self.browser.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
+        self.browser.setContextMenuPolicy(QtCore.Qt.ContextMenuPolicy.CustomContextMenu)
         self.browser.customContextMenuRequested.connect(self.browser_item_menu)
         self.browser.itemChanged.connect(self.browser_item_changed)
 
@@ -311,9 +311,10 @@ class ManagedWindowBase(QtGui.QMainWindow):
         if self.inputs_in_scrollarea:
             inputs_scroll = QtGui.QScrollArea()
             inputs_scroll.setWidgetResizable(True)
-            inputs_scroll.setFrameStyle(QtGui.QScrollArea.NoFrame)
+            inputs_scroll.setFrameStyle(QtGui.QScrollArea.Shape.NoFrame)
 
-            self.inputs.setSizePolicy(QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Fixed)
+            self.inputs.setSizePolicy(QtGui.QSizePolicy.Policy.Minimum,
+                                      QtGui.QSizePolicy.Policy.Fixed)
             inputs_scroll.setWidget(self.inputs)
             inputs_vbox.addWidget(inputs_scroll, 1)
 
@@ -330,26 +331,26 @@ class ManagedWindowBase(QtGui.QMainWindow):
 
         dock = QtGui.QDockWidget('Input Parameters')
         dock.setWidget(inputs_dock)
-        dock.setFeatures(QtGui.QDockWidget.NoDockWidgetFeatures)
-        self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, dock)
+        dock.setFeatures(QtGui.QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
+        self.addDockWidget(QtCore.Qt.DockWidgetArea.LeftDockWidgetArea, dock)
 
         if self.use_sequencer:
             sequencer_dock = QtGui.QDockWidget('Sequencer')
             sequencer_dock.setWidget(self.sequencer)
-            sequencer_dock.setFeatures(QtGui.QDockWidget.NoDockWidgetFeatures)
-            self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, sequencer_dock)
+            sequencer_dock.setFeatures(QtGui.QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
+            self.addDockWidget(QtCore.Qt.DockWidgetArea.LeftDockWidgetArea, sequencer_dock)
 
         if self.use_estimator:
             estimator_dock = QtGui.QDockWidget('Estimator')
             estimator_dock.setWidget(self.estimator)
-            estimator_dock.setFeatures(QtGui.QDockWidget.NoDockWidgetFeatures)
-            self.addDockWidget(QtCore.Qt.LeftDockWidgetArea, estimator_dock)
+            estimator_dock.setFeatures(QtGui.QDockWidget.DockWidgetFeature.NoDockWidgetFeatures)
+            self.addDockWidget(QtCore.Qt.DockWidgetArea.LeftDockWidgetArea, estimator_dock)
 
         self.tabs = QtGui.QTabWidget(self.main)
         for wdg in self.widget_list:
             self.tabs.addTab(wdg, wdg.name)
 
-        splitter = QtGui.QSplitter(QtCore.Qt.Vertical)
+        splitter = QtGui.QSplitter(QtCore.Qt.Orientation.Vertical)
         splitter.addWidget(self.tabs)
         splitter.addWidget(self.browser_widget)
 
@@ -430,17 +431,19 @@ class ManagedWindowBase(QtGui.QMainWindow):
     def remove_experiment(self, experiment):
         reply = QtGui.QMessageBox.question(self, 'Remove Graph',
                                            "Are you sure you want to remove the graph?",
-                                           QtGui.QMessageBox.Yes |
-                                           QtGui.QMessageBox.No, QtGui.QMessageBox.No)
-        if reply == QtGui.QMessageBox.Yes:
+                                           QtGui.QMessageBox.StandardButton.Yes |
+                                           QtGui.QMessageBox.StandardButton.No,
+                                           QtGui.QMessageBox.StandardButton.No)
+        if reply == QtGui.QMessageBox.StandardButton.Yes:
             self.manager.remove(experiment)
 
     def delete_experiment_data(self, experiment):
         reply = QtGui.QMessageBox.question(self, 'Delete Data',
                                            "Are you sure you want to delete this data file?",
-                                           QtGui.QMessageBox.Yes |
-                                           QtGui.QMessageBox.No, QtGui.QMessageBox.No)
-        if reply == QtGui.QMessageBox.Yes:
+                                           QtGui.QMessageBox.StandardButton.Yes |
+                                           QtGui.QMessageBox.StandardButton.No,
+                                           QtGui.QMessageBox.StandardButton.No)
+        if reply == QtGui.QMessageBox.StandardButton.Yes:
             self.manager.remove(experiment)
             os.unlink(experiment.data_filename)
 
@@ -448,13 +451,13 @@ class ManagedWindowBase(QtGui.QMainWindow):
         root = self.browser.invisibleRootItem()
         for i in range(root.childCount()):
             item = root.child(i)
-            item.setCheckState(0, QtCore.Qt.Checked)
+            item.setCheckState(0, QtCore.Qt.CheckState.Checked)
 
     def hide_experiments(self):
         root = self.browser.invisibleRootItem()
         for i in range(root.childCount()):
             item = root.child(i)
-            item.setCheckState(0, QtCore.Qt.Unchecked)
+            item.setCheckState(0, QtCore.Qt.CheckState.Unchecked)
 
     def clear_experiments(self):
         self.manager.clear()


### PR DESCRIPTION
@CasperSchippers, I have implemented few more fixes for `PyQt6` compatibility.

The fixes involve some replacements of `exec_` with `exec` and replacement of `QDirModel` with `QFileSystemModel`
Still there are some `exec_` that need to be updated, but for the moment I haven't found a solution (they are in `windows.py` file).
I think also that #695 should be merged first and your PR rebased with that changes.